### PR TITLE
docs: Mark project as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 
+> ⚠️ **DEPRECATED**: This project is no longer maintained. The functionality has been upgraded and moved to the new project [cursor-context](https://github.com/cursor-ai/cursor-context).
+
 All notable changes to the "funcmap" extension will be documented in this file.
+
+## [0.4.2] - 2024-03-22
+
+### Changed
+- Project marked as deprecated
+- Removed VS Code marketplace references
+- Updated documentation to point to cursor-context as the successor
 
 ## [0.4.1] - 2024-03-21
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# FuncMap
+# FuncMap [DEPRECATED]
+
+> ⚠️ **DEPRECATED**: This project is no longer maintained. The functionality has been upgraded and moved to the new project [cursor-context](https://github.com/cursor-ai/cursor-context). Please use that instead.
 
 AI-queryable function registry with Cursor Composer integration for enhanced development.
 
@@ -28,7 +30,7 @@ FuncMap helps you understand your codebase by:
 
 ## Installation
 
-1. Install the extension from the VS Code marketplace
+1. Clone this repository
 2. If using with Cursor Composer, create a `.cursorrules` file in your project root (see example below)
 3. Add AI tags to your functions to enhance searchability
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "funcmap",
-  "displayName": "FuncMap",
-  "description": "AI-queryable function registry with Cursor Composer integration for enhanced development",
-  "version": "0.4.1",
+  "displayName": "FuncMap [DEPRECATED]",
+  "description": "[DEPRECATED] AI-queryable function registry with Cursor Composer integration. Please use cursor-context instead.",
+  "version": "0.4.2",
   "publisher": "derungo",
+  "deprecated": true,
   "icon": "images/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Add deprecation notice and point to cursor-context\n- Remove VS Code marketplace references\n- Update version to 0.4.2\n- Update documentation to reflect deprecation status